### PR TITLE
Add functionality to refine direct beam position on hdf5 export

### DIFF
--- a/tvipsconverter/utils/recorder.py
+++ b/tvipsconverter/utils/recorder.py
@@ -833,7 +833,9 @@ class hdf5Intermediate(h5py.File):
                         and xmax < sdimx
                         and ymax < sdimy
                     ):
-                        sel = sel[ymin:ymax, xmin:xmax]
+                        sel = sel[
+                            ymin : ymax + 1, xmin : xmax + 1
+                        ]  # +1 to include final frame
                     else:
                         logger.warning(
                             "Aborting crop due to incorrect given dimensions: {}".format(

--- a/tvipsconverter/utils/recorder.py
+++ b/tvipsconverter/utils/recorder.py
@@ -555,7 +555,7 @@ class Recorder(QThread):
                 center[1] - side // 2 : center[1] + side // 2,
             ]
             # blur crop and find maximum -> use as center location
-            blurred = gaussian_filter(crop, sigma)
+            blurred = gaussian_filter(crop, sigma, mode="nearest")
             # add crop offset (center - side//2) to get actual location on frame
             ds.attrs["Center location"] = np.unravel_index(
                 blurred.argmax(), crop.shape

--- a/tvipsconverter/widget.ui
+++ b/tvipsconverter/widget.ui
@@ -788,7 +788,7 @@
                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diameter of the bo in which the direct beam spot will be found for all scanning positions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                    </property>
                    <property name="value">
-                    <number>30</number>
+                    <number>50</number>
                    </property>
                   </widget>
                  </item>
@@ -1167,7 +1167,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>1069</width>
+                <width>925</width>
                 <height>628</height>
                </rect>
               </property>

--- a/tvipsconverter/widget.ui
+++ b/tvipsconverter/widget.ui
@@ -82,7 +82,7 @@
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -1147,7 +1147,7 @@
        <item>
         <widget class="QTabWidget" name="tabWidget_3">
          <property name="currentIndex">
-          <number>1</number>
+          <number>0</number>
          </property>
          <widget class="QWidget" name="tab_2">
           <attribute name="title">
@@ -1167,7 +1167,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>925</width>
+                <width>1069</width>
                 <height>628</height>
                </rect>
               </property>

--- a/tvipsconverter/widget.ui
+++ b/tvipsconverter/widget.ui
@@ -157,7 +157,7 @@
             <x>0</x>
             <y>0</y>
             <width>1115</width>
-            <height>734</height>
+            <height>780</height>
            </rect>
           </property>
           <layout class="QHBoxLayout" name="horizontalLayout_11">
@@ -728,6 +728,9 @@
                 <layout class="QGridLayout" name="gridLayout_10">
                  <item row="0" column="0">
                   <widget class="QCheckBox" name="checkBox_maxiumum_image">
+                   <property name="toolTip">
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The maximum diffraction pattern represents the maximum intensity at each diffraction pattern pixel for all scanning positions. It is therefore instructive to the diffraction intensities recorded.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   </property>
                    <property name="text">
                     <string>Calculate maximum diffraction pattern</string>
                    </property>
@@ -736,8 +739,71 @@
                    </property>
                   </widget>
                  </item>
-                 <item row="0" column="1">
+                 <item row="2" column="4">
+                  <widget class="QSpinBox" name="spinBox_refine_center_sigma">
+                   <property name="toolTip">
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sigma should be set at least as large as the direct beam disk radius to accurately find the center point.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   </property>
+                   <property name="value">
+                    <number>5</number>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="3">
+                  <widget class="QLabel" name="label_41">
+                   <property name="toolTip">
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sigma should be set at least as large as the direct beam disk radius to accurately find the center point.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   </property>
+                   <property name="text">
+                    <string>Sigma</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="0">
+                  <widget class="QCheckBox" name="checkBox_refine_center">
+                   <property name="toolTip">
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The direct beam location will be refined and stored as metadata for each frame. This is done by blurring (sigma) a small central region (of diameter box size) and finding the peak position. Therefore box size should be large enough to encompass the direct beam entirely for all scnning pixels and sigma should be at least the disk radius.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   </property>
+                   <property name="text">
+                    <string>Refine direct beam position</string>
+                   </property>
+                   <property name="checked">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="1">
+                  <widget class="QLabel" name="label_40">
+                   <property name="toolTip">
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diameter of the bo in which the direct beam spot will be found for all scanning positions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   </property>
+                   <property name="text">
+                    <string>Box size</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="2">
+                  <widget class="QSpinBox" name="spinBox_refine_center_diameter">
+                   <property name="toolTip">
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diameter of the bo in which the direct beam spot will be found for all scanning positions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   </property>
+                   <property name="value">
+                    <number>30</number>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="0" colspan="5">
+                  <widget class="Line" name="line">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="1" colspan="4">
                   <widget class="QCheckBox" name="checkBox_average_image">
+                   <property name="toolTip">
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The average diffraction pattern represents the average intensity at each diffraction pattern pixel for all scanning positions. It is therefore instructive to the average diffraction over the whole scanning area.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   </property>
                    <property name="text">
                     <string>Calculate average diffraction pattern</string>
                    </property>
@@ -1081,7 +1147,7 @@
        <item>
         <widget class="QTabWidget" name="tabWidget_3">
          <property name="currentIndex">
-          <number>0</number>
+          <number>1</number>
          </property>
          <widget class="QWidget" name="tab_2">
           <attribute name="title">
@@ -1522,12 +1588,18 @@
                   </item>
                   <item>
                    <widget class="QGroupBox" name="groupBox_9">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Crop the output file size. Only the pixels within the crop bounds will be exported.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
                     <property name="title">
                      <string>Crop</string>
                     </property>
                     <layout class="QGridLayout" name="gridLayout_11">
                      <item row="1" column="5">
                       <widget class="QPushButton" name="pushButton_13">
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Crop the output file size. Only the pixels within the crop bounds will be exported.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
                        <property name="text">
                         <string>Show Cropped Region</string>
                        </property>
@@ -1535,6 +1607,9 @@
                      </item>
                      <item row="0" column="0">
                       <widget class="QLabel" name="label_36">
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Crop the output file size. Only the pixels within the crop bounds will be exported.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
                        <property name="text">
                         <string>xmin</string>
                        </property>
@@ -1542,6 +1617,9 @@
                      </item>
                      <item row="1" column="0">
                       <widget class="QLabel" name="label_37">
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Crop the output file size. Only the pixels within the crop bounds will be exported.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
                        <property name="text">
                         <string>ymin</string>
                        </property>
@@ -1554,6 +1632,9 @@
                          <width>93</width>
                          <height>0</height>
                         </size>
+                       </property>
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Crop the output file size. Only the pixels within the crop bounds will be exported.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>
                        <property name="minimum">
                         <number>0</number>
@@ -1574,6 +1655,9 @@
                          <height>0</height>
                         </size>
                        </property>
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Crop the output file size. Only the pixels within the crop bounds will be exported.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
                        <property name="maximum">
                         <number>1000</number>
                        </property>
@@ -1584,6 +1668,9 @@
                      </item>
                      <item row="0" column="3">
                       <widget class="QLabel" name="label_38">
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Crop the output file size. Only the pixels within the crop bounds will be exported.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
                        <property name="text">
                         <string>xmax</string>
                        </property>
@@ -1604,6 +1691,9 @@
                      </item>
                      <item row="1" column="3">
                       <widget class="QLabel" name="label_39">
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Crop the output file size. Only the pixels within the crop bounds will be exported.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
                        <property name="text">
                         <string>ymax</string>
                        </property>
@@ -1616,6 +1706,9 @@
                          <width>93</width>
                          <height>0</height>
                         </size>
+                       </property>
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Crop the output file size. Only the pixels within the crop bounds will be exported.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>
                        <property name="maximum">
                         <number>1000</number>
@@ -1632,6 +1725,9 @@
                          <width>93</width>
                          <height>0</height>
                         </size>
+                       </property>
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Crop the output file size. Only the pixels within the crop bounds will be exported.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>
                        <property name="maximum">
                         <number>1000</number>
@@ -1662,6 +1758,9 @@
                      </item>
                      <item row="0" column="0">
                       <widget class="QCheckBox" name="checkBox_rescale">
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked then the intensities in each frame will be rescaled between 0 and 255.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
                        <property name="text">
                         <string>Rescale intensities across 8-bit range</string>
                        </property>

--- a/tvipsconverter/widgets.py
+++ b/tvipsconverter/widgets.py
@@ -117,6 +117,10 @@ class ConnectedWidget(rawgui):
         self.pushButton_11.clicked.connect(self.export_tiffs)
         # show cropped region
         self.pushButton_13.clicked.connect(self.show_cropped_region)
+        # write scan settings (from VBF preview) to hdf5
+        # self.pushButton_write_scan_parameters.clicked.connect(
+        #     self.write_scan_parameters_hdf5
+        # )
 
     def export_preview(self):
         try:
@@ -458,6 +462,9 @@ class ConnectedWidget(rawgui):
                 self.update_line(self.lineEdit_3, "?")
             if star is not None:
                 self.update_line(self.lineEdit_5, str(star))
+                logger.info(f"start: {star}")
+                self.spinBox_15.setValue(star)
+                self.checkBox_11.setChecked(True)
             else:
                 self.update_line(self.lineEdit_5, "?")
             if en is not None:
@@ -469,7 +476,15 @@ class ConnectedWidget(rawgui):
             else:
                 self.update_line(self.lineEdit_11, "?")
             if dim is not None:
-                self.update_line(self.lineEdit_12, f"{str(int(dim))}x{str(int(dim))}")
+                if isinstance(dim, (list, tuple)):
+                    self.update_line(self.lineEdit_12, str(dim))
+                    self.spinBox.setValue(dim[0])
+                    self.spinBox_2.setValue(dim[1])
+                    self.checkBox_2.setChecked(True)
+                else:
+                    self.update_line(
+                        self.lineEdit_12, f"{str(int(dim))}x{str(int(dim))}"
+                    )
             else:
                 self.update_line(self.lineEdit_12, "?")
             self.update_line(self.lineEdit_13, f"{str(imdimx)}x{str(imdimy)}")
@@ -537,6 +552,7 @@ class ConnectedWidget(rawgui):
                 "hysteresis": hyst,
                 "winding_scan": snakescan,
             }
+
             # plot the image and store it for further use. First close prior
             # image
             if self.fig_vbf is not None:
@@ -561,6 +577,9 @@ class ConnectedWidget(rawgui):
             yshap, xshap = self.vbf_data.shape
             self.update_line(self.lineEdit_10, f"Size: {xshap}x{yshap}.")
             f.close()
+
+            # add settings to hdf5 file, do this after file close
+            rec.write_scan_parameters_hdf5(path_hdf5, **self.vbf_sets)
         except Exception as e:
             self.update_line(self.statusedit, f"Error: {e}")
 

--- a/tvipsconverter/widgets.py
+++ b/tvipsconverter/widgets.py
@@ -427,6 +427,11 @@ class ConnectedWidget(rawgui):
                 imrange=(start_frame, end_frame),
                 calcmax=self.checkBox_maxiumum_image.isChecked(),  # options kwarg
                 calcave=self.checkBox_average_image.isChecked(),  # options kwarg
+                refine_center=(
+                    self.checkBox_refine_center.isChecked(),
+                    self.spinBox_refine_center_diameter.value(),
+                    self.spinBox_refine_center_sigma.value(),
+                ),
             )
             self.get_thread.increase_progress.connect(self.increase_progbar)
             self.get_thread.finish.connect(self.done_hdf5export)


### PR DESCRIPTION
The direct beam location is determined at export time by selecting a small central region of each frame (box size), blurring it (sigma) and finding the maximum in this cropped image. The direct beam location is then added to the attributes of each frame. This option is user selectable.