### PR TITLE
Add option to have y-axis hysteresis

### DIFF
--- a/tvipsconverter/utils/blockfile.py
+++ b/tvipsconverter/utils/blockfile.py
@@ -482,6 +482,23 @@ class bloFileWriter(QThread):
 
     def convert_to_blo(self):
         endianess = "<"
+
+        # add optional parameters to blo header too
+        # None is deafault for not set
+        _options = dict()
+        _options["Recentering"] = (
+            True if "recenter" in self.options and self.options["recenter"] else False
+        )
+        _options["Binning"] = (
+            self.options["binning"] if "binning" in self.options else None
+        )
+        _options["Rescale"] = (
+            self.options["rescale"] if "rescale" in self.options else None
+        )
+        _options["Clip value"] = (
+            self.options["clip_max"] if "clip_max" in self.options else None
+        )
+
         header, note = get_header(
             self.shape,
             self.scan_scale,
@@ -492,6 +509,7 @@ class bloFileWriter(QThread):
             Distortion_N01=1.0,
             Distortion_N09=1.0,
             Note="Reconstructed from TVIPS image stream",
+            **_options,
         )
 
         logger.debug("Created header of blo file")

--- a/tvipsconverter/utils/blockfile.py
+++ b/tvipsconverter/utils/blockfile.py
@@ -185,8 +185,7 @@ def get_header_dtype_list(endianess="<"):
 
 
 def get_default_header(endianess="<"):
-    """Returns a header pre-populated with default values.
-    """
+    """Returns a header pre-populated with default values."""
     dt = np.dtype(get_header_dtype_list())
     header = np.zeros((1,), dtype=dt)
     header["ID"][0] = "IMGBLO".encode()
@@ -379,7 +378,10 @@ def file_reader(filename, endianess="<", mmap_mode=None, lazy=False, **kwds):
             "time_zone": time_zone,
             "notes": header["Note"],
         },
-        "Signal": {"signal_type": "diffraction", "record_by": "image",},
+        "Signal": {
+            "signal_type": "diffraction",
+            "record_by": "image",
+        },
     }
     # Create the axis objects for each axis
     dim = data.ndim
@@ -531,7 +533,7 @@ class bloFileWriter(QThread):
                 img = self.fh["ImageStream"][f"Frame_{c}"][:]
 
                 if "binning" in self.options and self.options["binning"] is not None:
-                    img = imagefun.bin_box(img, self.options["binning"])
+                    img = imagefun.bin_box(img, self.options["binning"], dtype=True)
 
                 if "clip_max" in self.options and self.options["clip_max"] is not None:
                     # define default clip limit
@@ -614,4 +616,3 @@ def file_writer_array(filename, array, scan_scale, diff_scale, **kwds):
             dp_head.tofile(f)
             img.astype(endianess + "u1").tofile(f)
             dp_head["ID"] += 1
-

--- a/tvipsconverter/utils/blockfile.py
+++ b/tvipsconverter/utils/blockfile.py
@@ -530,14 +530,20 @@ class bloFileWriter(QThread):
                 c = f"{indx}".zfill(6)
                 img = self.fh["ImageStream"][f"Frame_{c}"][:]
 
+                if "binning" in self.options and self.options["binning"] is not None:
+                    img = imagefun.bin_box(img, self.options["binning"])
+
                 if "clip_max" in self.options and self.options["clip_max"] is not None:
+                    # define default clip limit
                     _max = self.options["clip_max"]
                 else:
+                    # use default limit (max)
                     _max = None
 
                 if "rescale" in self.options and self.options["rescale"]:
                     img = imagefun.normalize_convert(img, dtype=np.uint8, max=_max)
                 else:
+                    # apply clipping if required then convert to 8-bit
                     if _max is not None:
                         img[img > _max] = _max
                     img = util.img_as_ubyte(img)

--- a/tvipsconverter/utils/blockfile.py
+++ b/tvipsconverter/utils/blockfile.py
@@ -530,9 +530,16 @@ class bloFileWriter(QThread):
                 c = f"{indx}".zfill(6)
                 img = self.fh["ImageStream"][f"Frame_{c}"][:]
 
-                if "rescale" in self.options and self.options["rescale"]:
-                    img = imagefun.normalize_convert(img, dtype=np.uint8)
+                if "clip_max" in self.options and self.options["clip_max"] is not None:
+                    _max = self.options["clip_max"]
                 else:
+                    _max = None
+
+                if "rescale" in self.options and self.options["rescale"]:
+                    img = imagefun.normalize_convert(img, dtype=np.uint8, max=_max)
+                else:
+                    if _max is not None:
+                        img[img > _max] = _max
                     img = util.img_as_ubyte(img)
                 img.astype(endianess + "u1").tofile(f)
                 dp_head["ID"] += 1

--- a/tvipsconverter/utils/imagefun.py
+++ b/tvipsconverter/utils/imagefun.py
@@ -257,7 +257,7 @@ def bin_box(arr, factor, axis=None, dtype=False):
 
     # should work ndim
     slices = []
-    for v in product(
+    for v in itertools.product(
         range(factor), repeat=len(axis)
     ):  # calculate all slicing offsets in all dimensions
         v = iter(v)

--- a/tvipsconverter/utils/imagefun.py
+++ b/tvipsconverter/utils/imagefun.py
@@ -206,7 +206,7 @@ def bin2(a, factor):
     return binned
 
 
-def bin_box(arr, factor, axis=None):
+def bin_box(arr, factor, axis=None, dtype=False):
     """
 
     Use box averaging to bin the images.
@@ -220,6 +220,11 @@ def bin_box(arr, factor, axis=None):
     axis: None, int, or tuple of ints
         Axis or axes to apply binning to.
         If None then all axes are binned.
+    keep_dtype: bool or dtype
+        If True then the output data type will be the same as arr.
+        If False then the output type deafults to np.float.
+        If dtype then this data type will be forced.
+
 
     Returns
     -------
@@ -252,7 +257,7 @@ def bin_box(arr, factor, axis=None):
 
     # should work ndim
     slices = []
-    for v in itertools.product(
+    for v in product(
         range(factor), repeat=len(axis)
     ):  # calculate all slicing offsets in all dimensions
         v = iter(v)
@@ -262,8 +267,15 @@ def bin_box(arr, factor, axis=None):
             temp.append(slice(next(v), None, factor) if i in axis else slice(None))
         slices.append(tuple(temp))
 
-    # stack th offset slices and take mean down stack axis to finish binning
-    return np.stack(tuple(arr[s] for s in slices), axis=0).mean(axis=0)
+    # sort output data type
+    if dtype is True:
+        dtype = arr.dtype
+    elif dtype is False:
+        dtype = None
+    # otherwise assume a valid data type
+
+    # stack the offset slices and take mean down stack axis to finish binning
+    return np.stack(tuple(arr[s] for s in slices), axis=0).mean(axis=0, dtype=dtype)
 
 
 def getElectronWavelength(ht):

--- a/tvipsconverter/utils/imagefun.py
+++ b/tvipsconverter/utils/imagefun.py
@@ -125,7 +125,7 @@ def linscale(arr, min=None, max=None, nmin=0, nmax=1, dtype=np.float):
         max = workarr.max()
     else:
         workarr[workarr > max] = max
-
+    
     a = (nmax - nmin) / (max - min)
     result = (workarr - min) * a + nmin
     return result.astype(dtype)
@@ -239,7 +239,7 @@ def bin_box(arr, factor, axis=None, dtype=False):
         axis = tuple(range(arr.ndim))
     else:
         if isinstance(axis, (int, np.integer)):
-            axes = (axis,)
+            axis = (axis,)
         else:
             assert isinstance(
                 axis, (list, tuple)

--- a/tvipsconverter/utils/recorder.py
+++ b/tvipsconverter/utils/recorder.py
@@ -578,7 +578,9 @@ class Recorder(QThread):
             # get all peaks in blurred image (at least sigma away from each other)
             coords = peak_local_max(blurred, sigma, exclude_border=1)
             # get peak closest to center
-            coords_center = coords[np.linalg.norm(coords - center, axis=1).argmin()]
+            coords_center = coords[
+                np.linalg.norm(coords - (side // 2, side // 2), axis=1).argmin()
+            ]
             # and reintroduce offset
             ds.attrs["Center location"] = coords_center + (center - side // 2)
 

--- a/tvipsconverter/utils/recorder.py
+++ b/tvipsconverter/utils/recorder.py
@@ -770,7 +770,9 @@ class hdf5Intermediate(h5py.File):
         start_frame=None,
         end_frame=None,
         hyst=0,
+        hyst_dir='x',
         snakescan=True,
+        snakescan_dir='x',
     ):
         # try to get the rotator data
         try:
@@ -788,7 +790,9 @@ class hdf5Intermediate(h5py.File):
             start_frame=start_frame,
             end_frame=end_frame,
             hyst=hyst,
+            hyst_dir=hyst_dir,
             snakescan=snakescan,
+            snakescan_dir=snakescan_dir,
         )
         logger.debug("Calculated scan indexes")
         if sdimx is None:
@@ -806,7 +810,9 @@ class hdf5Intermediate(h5py.File):
         start_frame=None,
         end_frame=None,
         hyst=0,
+        hyst_dir='x',
         snakescan=True,
+        snakescan_dir='x',
         crop=None,
         binning=None,
     ):
@@ -816,7 +822,9 @@ class hdf5Intermediate(h5py.File):
             start_frame=start_frame,
             end_frame=end_frame,
             hyst=hyst,
+            hyst_dir=hyst_dir,
             snakescan=snakescan,
+            snakescan_dir=snakescan_dir,
             crop=crop,
         )
         logger.debug("Calculated scan indexes")

--- a/tvipsconverter/utils/recorder.py
+++ b/tvipsconverter/utils/recorder.py
@@ -579,7 +579,7 @@ class Recorder(QThread):
             coords = peak_local_max(blurred, sigma, exclude_border=1)
             # get peak closest to center
             coords_center = coords[
-                np.linalg.norm(coords - (side // 2, side // 2), axis=1).argmin()
+                np.linalg.norm(coords - np.array(blurred.shape) // 2, axis=1).argmin()
             ]
             # and reintroduce offset
             ds.attrs["Center location"] = coords_center + (center - side // 2)

--- a/tvipsconverter/utils/recorder.py
+++ b/tvipsconverter/utils/recorder.py
@@ -847,9 +847,9 @@ class hdf5Intermediate(h5py.File):
         start_frame=None,
         end_frame=None,
         hyst=0,
-        hyst_dir='x',
+        hyst_dir="x",
         snakescan=True,
-        snakescan_dir='x',
+        snakescan_dir="x",
         crop=None,
     ):
         """Calculate the indexes of the list of frames to consider for the
@@ -887,16 +887,16 @@ class hdf5Intermediate(h5py.File):
             sel = sel.reshape(sdimy, sdimx)
             # reverse correct even scan lines
             if snakescan:
-                if snakescan_dir == 'x':
+                if snakescan_dir == "x":
                     sel[::2] = sel[::2][:, ::-1]
-                elif snakescan_dir == 'y':
+                elif snakescan_dir == "y":
                     sel[:, ::2] = sel[:, ::2][::-1, :]
                 else:
-                    logger.warning(f'snakescan_dir: {snakescan_dir} undefined.')
+                    logger.warning(f"snakescan_dir: {snakescan_dir} undefined.")
             # hysteresis correction on even scan lines
-            if hyst_dir == 'x':
+            if hyst_dir == "x":
                 sel[::2] = np.roll(sel[::2], hyst, axis=1)
-            elif hyst_dir == 'y':
+            elif hyst_dir == "y":
                 sel[:, ::2] = np.roll(sel[:, ::2], hyst, axis=0)
 
             # check for crop

--- a/tvipsconverter/utils/recorder.py
+++ b/tvipsconverter/utils/recorder.py
@@ -847,7 +847,9 @@ class hdf5Intermediate(h5py.File):
         start_frame=None,
         end_frame=None,
         hyst=0,
+        hyst_dir='x',
         snakescan=True,
+        snakescan_dir='x',
         crop=None,
     ):
         """Calculate the indexes of the list of frames to consider for the
@@ -885,9 +887,17 @@ class hdf5Intermediate(h5py.File):
             sel = sel.reshape(sdimy, sdimx)
             # reverse correct even scan lines
             if snakescan:
-                sel[::2] = sel[::2][:, ::-1]
+                if snakescan_dir == 'x':
+                    sel[::2] = sel[::2][:, ::-1]
+                elif snakescan_dir == 'y':
+                    sel[:, ::2] = sel[:, ::2][::-1, :]
+                else:
+                    logger.warning(f'snakescan_dir: {snakescan_dir} undefined.')
             # hysteresis correction on even scan lines
-            sel[::2] = np.roll(sel[::2], hyst, axis=1)
+            if hyst_dir == 'x':
+                sel[::2] = np.roll(sel[::2], hyst, axis=1)
+            elif hyst_dir == 'y':
+                sel[:, ::2] = np.roll(sel[:, ::2], hyst, axis=0)
 
             # check for crop
             if crop is not None:

--- a/tvipsconverter/widget.ui
+++ b/tvipsconverter/widget.ui
@@ -1166,9 +1166,9 @@
               <property name="geometry">
                <rect>
                 <x>0</x>
-                <y>-53</y>
+                <y>-61</y>
                 <width>1069</width>
-                <height>660</height>
+                <height>699</height>
                </rect>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_2">
@@ -1761,6 +1761,16 @@
                       </widget>
                      </item>
                      <item row="0" column="2">
+                      <widget class="QCheckBox" name="checkBox_clipmax_blo">
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Clip maximum value in diffraction patterns to this value.  It is recommended to use in conjunction with rescale in order to take full advantage of these capabilities.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                       <property name="text">
+                        <string>Clip maximum value</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="3">
                       <widget class="QSpinBox" name="spinBox_clipmax_blo">
                        <property name="toolTip">
                         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Clip maximum value in diffraction patterns to this value.  It is recommended to use in conjunction with rescale in order to take full advantage of these capabilities.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -1774,16 +1784,6 @@
                       </widget>
                      </item>
                      <item row="0" column="1">
-                      <widget class="QCheckBox" name="checkBox_clipmax_blo">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Clip maximum value in diffraction patterns to this value.  It is recommended to use in conjunction with rescale in order to take full advantage of these capabilities.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>Clip maximum value</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="0" column="3">
                       <spacer name="horizontalSpacer_15">
                        <property name="orientation">
                         <enum>Qt::Horizontal</enum>
@@ -1796,19 +1796,48 @@
                        </property>
                       </spacer>
                      </item>
-                     <item row="1" column="2">
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_13">
+                    <property name="title">
+                     <string>Other</string>
+                    </property>
+                    <layout class="QGridLayout" name="gridLayout_14">
+                     <item row="0" column="3">
+                      <widget class="QCheckBox" name="checkBox_center_frame">
+                       <property name="text">
+                        <string>Center each frame?</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="1">
                       <widget class="QSpinBox" name="spinBox_binning_blo">
                        <property name="suffix">
                         <string>x</string>
                        </property>
                       </widget>
                      </item>
-                     <item row="1" column="1">
+                     <item row="0" column="0">
                       <widget class="QCheckBox" name="checkBox_binning_blo">
                        <property name="text">
                         <string>Apply binning</string>
                        </property>
                       </widget>
+                     </item>
+                     <item row="0" column="2">
+                      <spacer name="horizontalSpacer_16">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
                      </item>
                     </layout>
                    </widget>

--- a/tvipsconverter/widget.ui
+++ b/tvipsconverter/widget.ui
@@ -1166,9 +1166,9 @@
               <property name="geometry">
                <rect>
                 <x>0</x>
-                <y>0</y>
+                <y>-53</y>
                 <width>1069</width>
-                <height>629</height>
+                <height>660</height>
                </rect>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_2">
@@ -1750,6 +1750,29 @@
                      <string>8-bit conversion</string>
                     </property>
                     <layout class="QGridLayout" name="gridLayout_12">
+                     <item row="0" column="0">
+                      <widget class="QCheckBox" name="checkBox_rescale">
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked then the intensities in each frame will be rescaled between 0 and 255.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                       <property name="text">
+                        <string>Rescale intensities across 8-bit range</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="2">
+                      <widget class="QSpinBox" name="spinBox_clipmax_blo">
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Clip maximum value in diffraction patterns to this value.  It is recommended to use in conjunction with rescale in order to take full advantage of these capabilities.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                       <property name="maximum">
+                        <number>65535</number>
+                       </property>
+                       <property name="value">
+                        <number>65535</number>
+                       </property>
+                      </widget>
+                     </item>
                      <item row="0" column="1">
                       <widget class="QCheckBox" name="checkBox_clipmax_blo">
                        <property name="toolTip">
@@ -1773,26 +1796,17 @@
                        </property>
                       </spacer>
                      </item>
-                     <item row="0" column="0">
-                      <widget class="QCheckBox" name="checkBox_rescale">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked then the intensities in each frame will be rescaled between 0 and 255.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="text">
-                        <string>Rescale intensities across 8-bit range</string>
+                     <item row="1" column="2">
+                      <widget class="QSpinBox" name="spinBox_binning_blo">
+                       <property name="suffix">
+                        <string>x</string>
                        </property>
                       </widget>
                      </item>
-                     <item row="0" column="2">
-                      <widget class="QSpinBox" name="spinBox_clipmax_blo">
-                       <property name="toolTip">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Clip maximum value in diffraction patterns to this value.  It is recommended to use in conjunction with rescale in order to take full advantage of these capabilities.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="maximum">
-                        <number>65535</number>
-                       </property>
-                       <property name="value">
-                        <number>65535</number>
+                     <item row="1" column="1">
+                      <widget class="QCheckBox" name="checkBox_binning_blo">
+                       <property name="text">
+                        <string>Apply binning</string>
                        </property>
                       </widget>
                      </item>

--- a/tvipsconverter/widget.ui
+++ b/tvipsconverter/widget.ui
@@ -82,7 +82,7 @@
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -1168,7 +1168,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>1069</width>
-                <height>628</height>
+                <height>629</height>
                </rect>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_2">
@@ -1751,6 +1751,16 @@
                     </property>
                     <layout class="QGridLayout" name="gridLayout_12">
                      <item row="0" column="1">
+                      <widget class="QCheckBox" name="checkBox_clipmax_blo">
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Clip maximum value in diffraction patterns to this value.  It is recommended to use in conjunction with rescale in order to take full advantage of these capabilities.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                       <property name="text">
+                        <string>Clip maximum value</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="3">
                       <spacer name="horizontalSpacer_15">
                        <property name="orientation">
                         <enum>Qt::Horizontal</enum>
@@ -1770,6 +1780,19 @@
                        </property>
                        <property name="text">
                         <string>Rescale intensities across 8-bit range</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="2">
+                      <widget class="QSpinBox" name="spinBox_clipmax_blo">
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Clip maximum value in diffraction patterns to this value.  It is recommended to use in conjunction with rescale in order to take full advantage of these capabilities.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                       <property name="maximum">
+                        <number>65535</number>
+                       </property>
+                       <property name="value">
+                        <number>65535</number>
                        </property>
                       </widget>
                      </item>

--- a/tvipsconverter/widget.ui
+++ b/tvipsconverter/widget.ui
@@ -1166,9 +1166,9 @@
               <property name="geometry">
                <rect>
                 <x>0</x>
-                <y>-61</y>
+                <y>0</y>
                 <width>1069</width>
-                <height>699</height>
+                <height>717</height>
                </rect>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_2">
@@ -1416,7 +1416,7 @@
                         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Frame in the stream where the scan began&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>
                        <property name="text">
-                        <string>Scan start frame</string>
+                        <string>Start</string>
                        </property>
                       </widget>
                      </item>
@@ -1566,7 +1566,7 @@
                         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Frame at which the scanning stopped. If not auto-calculated must be (first frame + scan dim x * scan dim y)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>
                        <property name="text">
-                        <string>Scan stop frame</string>
+                        <string>Stop</string>
                        </property>
                       </widget>
                      </item>
@@ -1581,6 +1581,34 @@
                        <property name="text">
                         <string>pixels</string>
                        </property>
+                      </widget>
+                     </item>
+                     <item row="6" column="4">
+                      <widget class="QComboBox" name="comboBox_hyst_dir">
+                       <item>
+                        <property name="text">
+                         <string>x</string>
+                        </property>
+                       </item>
+                       <item>
+                        <property name="text">
+                         <string>y</string>
+                        </property>
+                       </item>
+                      </widget>
+                     </item>
+                     <item row="7" column="1">
+                      <widget class="QComboBox" name="comboBox_snakescan_dir">
+                       <item>
+                        <property name="text">
+                         <string>x</string>
+                        </property>
+                       </item>
+                       <item>
+                        <property name="text">
+                         <string>y</string>
+                        </property>
+                       </item>
                       </widget>
                      </item>
                     </layout>

--- a/tvipsconverter/widget.ui
+++ b/tvipsconverter/widget.ui
@@ -82,7 +82,7 @@
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -157,7 +157,7 @@
             <x>0</x>
             <y>0</y>
             <width>1115</width>
-            <height>780</height>
+            <height>741</height>
            </rect>
           </property>
           <layout class="QHBoxLayout" name="horizontalLayout_11">
@@ -613,15 +613,22 @@
                    <property name="toolTip">
                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;x and y offset of the virtual aperture from the center of the image.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                    </property>
-                   <layout class="QHBoxLayout" name="horizontalLayout_3">
-                    <item>
-                     <widget class="QLabel" name="label_21">
+                   <layout class="QGridLayout" name="gridLayout_13">
+                    <item row="0" column="4">
+                     <widget class="QLabel" name="label_26">
                       <property name="text">
-                       <string>x-offset</string>
+                       <string>pixels</string>
                       </property>
                      </widget>
                     </item>
-                    <item>
+                    <item row="1" column="2">
+                     <widget class="QLabel" name="label_20">
+                      <property name="text">
+                       <string>pixels</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="0" column="1">
                      <widget class="QSpinBox" name="spinBox_13">
                       <property name="minimum">
                        <number>-100000</number>
@@ -631,31 +638,21 @@
                       </property>
                      </widget>
                     </item>
-                    <item>
+                    <item row="0" column="0">
+                     <widget class="QLabel" name="label_21">
+                      <property name="text">
+                       <string>x-offset</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="0" column="2">
                      <widget class="QLabel" name="label_22">
                       <property name="text">
                        <string>y-offset</string>
                       </property>
                      </widget>
                     </item>
-                    <item>
-                     <widget class="QSpinBox" name="spinBox_14">
-                      <property name="minimum">
-                       <number>-100000</number>
-                      </property>
-                      <property name="maximum">
-                       <number>100000</number>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QLabel" name="label_26">
-                      <property name="text">
-                       <string>pixels</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
+                    <item row="0" column="5">
                      <spacer name="horizontalSpacer_4">
                       <property name="orientation">
                        <enum>Qt::Horizontal</enum>
@@ -668,20 +665,17 @@
                       </property>
                      </spacer>
                     </item>
-                   </layout>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QWidget" name="widget_2" native="true">
-                   <layout class="QHBoxLayout" name="horizontalLayout_6">
-                    <item>
-                     <widget class="QLabel" name="label_19">
-                      <property name="text">
-                       <string>Aperture radius</string>
+                    <item row="0" column="3">
+                     <widget class="QSpinBox" name="spinBox_14">
+                      <property name="minimum">
+                       <number>-100000</number>
+                      </property>
+                      <property name="maximum">
+                       <number>100000</number>
                       </property>
                      </widget>
                     </item>
-                    <item>
+                    <item row="1" column="1">
                      <widget class="QSpinBox" name="spinBox_12">
                       <property name="minimum">
                        <number>1</number>
@@ -694,14 +688,14 @@
                       </property>
                      </widget>
                     </item>
-                    <item>
-                     <widget class="QLabel" name="label_20">
+                    <item row="1" column="0">
+                     <widget class="QLabel" name="label_19">
                       <property name="text">
-                       <string>pixels</string>
+                       <string>Aperture radius</string>
                       </property>
                      </widget>
                     </item>
-                    <item>
+                    <item row="1" column="3" colspan="3">
                      <spacer name="horizontalSpacer_3">
                       <property name="orientation">
                        <enum>Qt::Horizontal</enum>
@@ -713,6 +707,59 @@
                        </size>
                       </property>
                      </spacer>
+                    </item>
+                    <item row="2" column="0">
+                     <widget class="QCheckBox" name="checkBox_refine_center">
+                      <property name="toolTip">
+                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The direct beam location will be refined and stored as metadata for each frame. This is done by blurring (sigma) a small central region (of diameter box size) and finding the peak position. Therefore box size should be large enough to encompass the direct beam entirely for all scnning pixels and sigma should be at least the disk radius.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                      </property>
+                      <property name="text">
+                       <string>Refine direct beam position:</string>
+                      </property>
+                      <property name="checked">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="2" column="5">
+                     <widget class="QSpinBox" name="spinBox_refine_center_sigma">
+                      <property name="toolTip">
+                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sigma should be set at least as large as the direct beam disk radius to accurately find the center point.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                      </property>
+                      <property name="value">
+                       <number>5</number>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="2" column="4">
+                     <widget class="QLabel" name="label_41">
+                      <property name="toolTip">
+                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sigma should be set at least as large as the direct beam disk radius to accurately find the center point.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                      </property>
+                      <property name="text">
+                       <string>Sigma</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="2" column="3">
+                     <widget class="QSpinBox" name="spinBox_refine_center_diameter">
+                      <property name="toolTip">
+                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diameter of the bo in which the direct beam spot will be found for all scanning positions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                      </property>
+                      <property name="value">
+                       <number>50</number>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="2" column="2">
+                     <widget class="QLabel" name="label_40">
+                      <property name="toolTip">
+                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diameter of the bo in which the direct beam spot will be found for all scanning positions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                      </property>
+                      <property name="text">
+                       <string>Box size</string>
+                      </property>
+                     </widget>
                     </item>
                    </layout>
                   </widget>
@@ -732,80 +779,33 @@
                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The maximum diffraction pattern represents the maximum intensity at each diffraction pattern pixel for all scanning positions. It is therefore instructive to the diffraction intensities recorded.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                    </property>
                    <property name="text">
-                    <string>Calculate maximum diffraction pattern</string>
+                    <string>Maximum frame</string>
                    </property>
                    <property name="checked">
                     <bool>true</bool>
                    </property>
                   </widget>
                  </item>
-                 <item row="2" column="4">
-                  <widget class="QSpinBox" name="spinBox_refine_center_sigma">
+                 <item row="0" column="1">
+                  <widget class="QCheckBox" name="checkBox_sum_image">
                    <property name="toolTip">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sigma should be set at least as large as the direct beam disk radius to accurately find the center point.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="value">
-                    <number>5</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="3">
-                  <widget class="QLabel" name="label_41">
-                   <property name="toolTip">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sigma should be set at least as large as the direct beam disk radius to accurately find the center point.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Calculate the sum of each frame and store in the frame attributes as 'framesum'.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                    </property>
                    <property name="text">
-                    <string>Sigma</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="0">
-                  <widget class="QCheckBox" name="checkBox_refine_center">
-                   <property name="toolTip">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The direct beam location will be refined and stored as metadata for each frame. This is done by blurring (sigma) a small central region (of diameter box size) and finding the peak position. Therefore box size should be large enough to encompass the direct beam entirely for all scnning pixels and sigma should be at least the disk radius.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="text">
-                    <string>Refine direct beam position</string>
+                    <string>Sum frame</string>
                    </property>
                    <property name="checked">
                     <bool>true</bool>
                    </property>
                   </widget>
                  </item>
-                 <item row="2" column="1">
-                  <widget class="QLabel" name="label_40">
-                   <property name="toolTip">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diameter of the bo in which the direct beam spot will be found for all scanning positions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="text">
-                    <string>Box size</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="2">
-                  <widget class="QSpinBox" name="spinBox_refine_center_diameter">
-                   <property name="toolTip">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diameter of the bo in which the direct beam spot will be found for all scanning positions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="value">
-                    <number>50</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="0" colspan="5">
-                  <widget class="Line" name="line">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1" colspan="4">
+                 <item row="0" column="2" colspan="2">
                   <widget class="QCheckBox" name="checkBox_average_image">
                    <property name="toolTip">
                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The average diffraction pattern represents the average intensity at each diffraction pattern pixel for all scanning positions. It is therefore instructive to the average diffraction over the whole scanning area.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                    </property>
                    <property name="text">
-                    <string>Calculate average diffraction pattern</string>
+                    <string>Average frame</string>
                    </property>
                    <property name="checked">
                     <bool>true</bool>

--- a/tvipsconverter/widgets.py
+++ b/tvipsconverter/widgets.py
@@ -541,7 +541,7 @@ class ConnectedWidget(rawgui):
                 f"hyst: {hyst}"
             )
             self.vbf_data = f.get_vbf_image(
-                sdimx, sdimy, start_frame, end_frame, hyst, snakescan
+                sdimx, sdimy, start_frame, end_frame, hyst, hyst_dir, snakescan, snakescan_dir
             )
             logger.debug("Succesfully created the VBF array")
             # save the settings for later storage

--- a/tvipsconverter/widgets.py
+++ b/tvipsconverter/widgets.py
@@ -541,7 +541,14 @@ class ConnectedWidget(rawgui):
                 f"hyst: {hyst}"
             )
             self.vbf_data = f.get_vbf_image(
-                sdimx, sdimy, start_frame, end_frame, hyst, hyst_dir, snakescan, snakescan_dir
+                sdimx,
+                sdimy,
+                start_frame,
+                end_frame,
+                hyst,
+                self.combobox_hyst_dir.text(),
+                snakescan,
+                self.combobox_snakescan_dir.text(),
             )
             logger.debug("Succesfully created the VBF array")
             # save the settings for later storage

--- a/tvipsconverter/widgets.py
+++ b/tvipsconverter/widgets.py
@@ -668,6 +668,11 @@ class ConnectedWidget(rawgui):
                         if self.checkBox_clipmax_blo.isChecked()
                         else None
                     ),
+                    binning=(
+                        self.spinBox_binning_blo.value()
+                        if self.checkBox_binning_blo.isChecked()
+                        else None
+                    ),
                 )
             elif filetyp == ".hspy":
                 self.get_thread = hspf.hspyFileWriter(

--- a/tvipsconverter/widgets.py
+++ b/tvipsconverter/widgets.py
@@ -546,9 +546,9 @@ class ConnectedWidget(rawgui):
                 start_frame,
                 end_frame,
                 hyst,
-                self.combobox_hyst_dir.text(),
+                self.comboBox_hyst_dir.currentText(),
                 snakescan,
-                self.combobox_snakescan_dir.text(),
+                self.comboBox_snakescan_dir.currentText(),
             )
             logger.debug("Succesfully created the VBF array")
             # save the settings for later storage
@@ -667,7 +667,9 @@ class ConnectedWidget(rawgui):
                 start_frame,
                 end_frame,
                 hyst,
+                self.comboBox_hyst_dir.currentText(),
                 snakescan,
+                self.comboBox_snakescan_dir.currentText(),
                 crop=crop,
                 binning=binning,
             )

--- a/tvipsconverter/widgets.py
+++ b/tvipsconverter/widgets.py
@@ -431,7 +431,8 @@ class ConnectedWidget(rawgui):
                 imrange=(start_frame, end_frame),
                 calcmax=self.checkBox_maxiumum_image.isChecked(),  # options kwarg
                 calcave=self.checkBox_average_image.isChecked(),  # options kwarg
-                refine_center=(
+                calcsum=self.checkBox_sum_image.isChecked(),  # options kwarg
+                refine_center=(  # options kwarg
                     self.checkBox_refine_center.isChecked(),
                     self.spinBox_refine_center_diameter.value(),
                     self.spinBox_refine_center_sigma.value(),

--- a/tvipsconverter/widgets.py
+++ b/tvipsconverter/widgets.py
@@ -683,7 +683,7 @@ class ConnectedWidget(rawgui):
                         else None
                     ),
                     binning=binning,
-                    recenter=self.chechBox_center_frame.isChecked(),
+                    recenter=self.checkBox_center_frame.isChecked(),
                 )
             elif filetyp == ".hspy":
                 self.get_thread = hspf.hspyFileWriter(

--- a/tvipsconverter/widgets.py
+++ b/tvipsconverter/widgets.py
@@ -663,6 +663,11 @@ class ConnectedWidget(rawgui):
                     dp_scale,
                     # if rescale button is checked do rescale, otherwise no rescaling selected
                     rescale=self.checkBox_rescale.isChecked(),
+                    clip_max=(
+                        self.spinBox_clipmax_blo.value()
+                        if self.checkBox_clipmax_blo.isChecked()
+                        else None
+                    ),
                 )
             elif filetyp == ".hspy":
                 self.get_thread = hspf.hspyFileWriter(

--- a/tvipsconverter/widgets.py
+++ b/tvipsconverter/widgets.py
@@ -162,9 +162,7 @@ class ConnectedWidget(rawgui):
                 scene = QGraphicsScene()
                 scene.addWidget(canvas)
                 self.graphicsView_3.setScene(scene)
-                self.graphicsView_3.fitInView(
-                    scene.sceneRect(),
-                )
+                self.graphicsView_3.fitInView(scene.sceneRect(),)
                 self.repaint_widget(self.graphicsView_3)
             except Exception as e:
                 logger.debug(f"Error: {e}")
@@ -685,6 +683,7 @@ class ConnectedWidget(rawgui):
                         else None
                     ),
                     binning=binning,
+                    recenter=self.chechBox_center_frame.isChecked(),
                 )
             elif filetyp == ".hspy":
                 self.get_thread = hspf.hspyFileWriter(
@@ -789,15 +788,13 @@ class ConnectedWidget(rawgui):
         # check cropping dimension > 0
         if not xmax - xmin > 0:
             self.update_line(
-                self.statusedit,
-                f"Crop dimension incorrect. Crop x: {xmax - xmin}.",
+                self.statusedit, f"Crop dimension incorrect. Crop x: {xmax - xmin}.",
             )
             self.remove_cropped_region()
             return
         if not ymax - ymin > 0:
             self.update_line(
-                self.statusedit,
-                f"Crop dimension incorrect. Crop y: {ymax - ymin}.",
+                self.statusedit, f"Crop dimension incorrect. Crop y: {ymax - ymin}.",
             )
             self.remove_cropped_region()
             return
@@ -814,8 +811,7 @@ class ConnectedWidget(rawgui):
 
         if self.fig_vbf is None:
             self.update_line(
-                self.statusedit,
-                "No VBF figure plotted yet.",
+                self.statusedit, "No VBF figure plotted yet.",
             )
             return
 
@@ -844,8 +840,7 @@ class ConnectedWidget(rawgui):
         self.fig_vbf.canvas.draw()
 
         self.update_line(
-            self.statusedit,
-            f"Crop dimensions (x, y): ({xmax - xmin}, {ymax - ymin}).",
+            self.statusedit, f"Crop dimensions (x, y): ({xmax - xmin}, {ymax - ymin}).",
         )
 
 

--- a/tvipsconverter/widgets.py
+++ b/tvipsconverter/widgets.py
@@ -162,7 +162,9 @@ class ConnectedWidget(rawgui):
                 scene = QGraphicsScene()
                 scene.addWidget(canvas)
                 self.graphicsView_3.setScene(scene)
-                self.graphicsView_3.fitInView(scene.sceneRect(),)
+                self.graphicsView_3.fitInView(
+                    scene.sceneRect(),
+                )
                 self.repaint_widget(self.graphicsView_3)
             except Exception as e:
                 logger.debug(f"Error: {e}")
@@ -647,8 +649,22 @@ class ConnectedWidget(rawgui):
             else:
                 crop = None
 
+            # export binning option setup
+            binning = (
+                self.spinBox_binning_blo.value()
+                if self.checkBox_binning_blo.isChecked()
+                else None
+            )
+
             shape, indexes = f.get_blo_export_data(
-                sdimx, sdimy, start_frame, end_frame, hyst, snakescan, crop=crop
+                sdimx,
+                sdimy,
+                start_frame,
+                end_frame,
+                hyst,
+                snakescan,
+                crop=crop,
+                binning=binning,
             )
             logger.debug(f"Shape: {shape}")
             logger.debug(f"Starting to write {filetyp} file")
@@ -668,11 +684,7 @@ class ConnectedWidget(rawgui):
                         if self.checkBox_clipmax_blo.isChecked()
                         else None
                     ),
-                    binning=(
-                        self.spinBox_binning_blo.value()
-                        if self.checkBox_binning_blo.isChecked()
-                        else None
-                    ),
+                    binning=binning,
                 )
             elif filetyp == ".hspy":
                 self.get_thread = hspf.hspyFileWriter(
@@ -777,13 +789,15 @@ class ConnectedWidget(rawgui):
         # check cropping dimension > 0
         if not xmax - xmin > 0:
             self.update_line(
-                self.statusedit, f"Crop dimension incorrect. Crop x: {xmax - xmin}.",
+                self.statusedit,
+                f"Crop dimension incorrect. Crop x: {xmax - xmin}.",
             )
             self.remove_cropped_region()
             return
         if not ymax - ymin > 0:
             self.update_line(
-                self.statusedit, f"Crop dimension incorrect. Crop y: {ymax - ymin}.",
+                self.statusedit,
+                f"Crop dimension incorrect. Crop y: {ymax - ymin}.",
             )
             self.remove_cropped_region()
             return
@@ -800,7 +814,8 @@ class ConnectedWidget(rawgui):
 
         if self.fig_vbf is None:
             self.update_line(
-                self.statusedit, "No VBF figure plotted yet.",
+                self.statusedit,
+                "No VBF figure plotted yet.",
             )
             return
 
@@ -829,7 +844,8 @@ class ConnectedWidget(rawgui):
         self.fig_vbf.canvas.draw()
 
         self.update_line(
-            self.statusedit, f"Crop dimensions (x, y): ({xmax - xmin}, {ymax - ymin}).",
+            self.statusedit,
+            f"Crop dimensions (x, y): ({xmax - xmin}, {ymax - ymin}).",
         )
 
 


### PR DESCRIPTION
In the case of 90 degree scans any hysteresis may be along y and not x, therefore add the option to have hysteresis along y. Comboboxes are added for this behaviour, but default (x) behaviour remains unchanged.